### PR TITLE
upgrade bootstrap-icons to v1.5.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1325 icons from svelte-bootstrap-icons@1.4.0.
+> 1370 icons from svelte-bootstrap-icons@1.4.1.
 
 ## Usage
 
@@ -135,6 +135,8 @@
 - BagXFill
 - BagX
 - Bag
+- Bank
+- Bank2
 - BarChartFill
 - BarChartLineFill
 - BarChartLine
@@ -151,6 +153,8 @@
 - BatteryHalf
 - Battery
 - BellFill
+- BellSlashFill
+- BellSlash
 - Bell
 - Bezier
 - Bezier2
@@ -339,6 +343,7 @@
 - Cart2
 - Cart3
 - Cart4
+- CashCoin
 - CashStack
 - Cash
 - Cast
@@ -377,6 +382,7 @@
 - CheckAll
 - CheckCircleFill
 - CheckCircle
+- CheckLg
 - CheckSquareFill
 - CheckSquare
 - Check
@@ -470,6 +476,7 @@
 - CodeSlash
 - CodeSquare
 - Code
+- Coin
 - CollectionFill
 - CollectionPlayFill
 - CollectionPlay
@@ -494,12 +501,19 @@
 - CupFill
 - CupStraw
 - Cup
+- CurrencyBitcoin
+- CurrencyDollar
+- CurrencyEuro
+- CurrencyExchange
+- CurrencyPound
+- CurrencyYen
 - CursorFill
 - CursorText
 - Cursor
 - DashCircleDotted
 - DashCircleFill
 - DashCircle
+- DashLg
 - DashSquareDotted
 - DashSquareFill
 - DashSquare
@@ -579,6 +593,7 @@
 - ExclamationCircle
 - ExclamationDiamondFill
 - ExclamationDiamond
+- ExclamationLg
 - ExclamationOctagonFill
 - ExclamationOctagon
 - ExclamationSquareFill
@@ -645,6 +660,8 @@
 - FileEarmarkMinus
 - FileEarmarkMusicFill
 - FileEarmarkMusic
+- FileEarmarkPdfFill
+- FileEarmarkPdf
 - FileEarmarkPersonFill
 - FileEarmarkPerson
 - FileEarmarkPlayFill
@@ -691,6 +708,8 @@
 - FileMinus
 - FileMusicFill
 - FileMusic
+- FilePdfFill
+- FilePdf
 - FilePersonFill
 - FilePerson
 - FilePlayFill
@@ -756,6 +775,10 @@
 - GearWide
 - Gear
 - Gem
+- GenderAmbiguous
+- GenderFemale
+- GenderMale
+- GenderTrans
 - GeoAltFill
 - GeoAlt
 - GeoFill
@@ -801,6 +824,7 @@
 - HddStack
 - Hdd
 - Headphones
+- HeadsetVr
 - Headset
 - HeartFill
 - HeartHalf
@@ -831,6 +855,7 @@
 - Inboxes
 - InfoCircleFill
 - InfoCircle
+- InfoLg
 - InfoSquareFill
 - InfoSquare
 - Info
@@ -912,6 +937,7 @@
 - MarkdownFill
 - Markdown
 - Mask
+- Mastodon
 - MegaphoneFill
 - Megaphone
 - MenuAppFill
@@ -922,6 +948,7 @@
 - MenuButton
 - MenuDown
 - MenuUp
+- Messenger
 - MicFill
 - MicMuteFill
 - MicMute
@@ -1015,9 +1042,13 @@
 - Phone
 - PieChartFill
 - PieChart
+- PiggyBankFill
+- PiggyBank
 - PinAngleFill
 - PinAngle
 - PinFill
+- PinMapFill
+- PinMap
 - Pin
 - PipFill
 - Pip
@@ -1032,6 +1063,7 @@
 - PlusCircleDotted
 - PlusCircleFill
 - PlusCircle
+- PlusLg
 - PlusSquareDotted
 - PlusSquareFill
 - PlusSquare
@@ -1045,6 +1077,7 @@
 - QuestionCircle
 - QuestionDiamondFill
 - QuestionDiamond
+- QuestionLg
 - QuestionOctagonFill
 - QuestionOctagon
 - QuestionSquareFill
@@ -1066,6 +1099,8 @@
 - Record
 - Record2Fill
 - Record2
+- Recycle
+- Reddit
 - ReplyAllFill
 - ReplyAll
 - ReplyFill
@@ -1073,12 +1108,18 @@
 - RssFill
 - Rss
 - Rulers
+- SafeFill
+- Safe
+- Safe2Fill
+- Safe2
 - SaveFill
 - Save
 - Save2Fill
 - Save2
 - Scissors
 - Screwdriver
+- SdCardFill
+- SdCard
 - Search
 - SegmentedNav
 - Server
@@ -1138,9 +1179,11 @@
 - SkipStartCircle
 - SkipStartFill
 - SkipStart
+- Skype
 - Slack
 - SlashCircleFill
 - SlashCircle
+- SlashLg
 - SlashSquareFill
 - SlashSquare
 - Slash
@@ -1258,6 +1301,7 @@
 - Toggles2
 - Tools
 - Tornado
+- Translate
 - TrashFill
 - Trash
 - Trash2Fill
@@ -1331,6 +1375,7 @@
 - XCircle
 - XDiamondFill
 - XDiamond
+- XLg
 - XOctagonFill
 - XOctagon
 - XSquareFill

--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ Refer to [ICON_INDEX.md](./ICON_INDEX.md) for a full list of supported icons.
 <script>
   import {
     Alarm,
+    Bank,
     CloudMoon,
     Github,
     PaintBucket,
     Wrench,
-    ZoomOut,
   } from "svelte-bootstrap-icons";
 </script>
 
 <Alarm />
+<Bank />
 <CloudMoon />
 <Github />
 <PaintBucket />
 <Wrench />
-<ZoomOut />
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "svelte-check --workspace=test"
   },
   "devDependencies": {
-    "bootstrap-icons": "1.4.1",
-    "rollup": "^2.46.0",
+    "bootstrap-icons": "1.5.0",
+    "rollup": "^2.47.0",
     "svelte-check": "^1.5.2",
     "svelte-readme": "^3.1.0",
     "svg-to-svelte": "^2.2.0"

--- a/test/BootstrapIcons.test.svelte
+++ b/test/BootstrapIcons.test.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     Alarm,
+    Bank,
     CloudMoon,
     Github,
     PaintBucket,
@@ -11,6 +12,7 @@
 </script>
 
 <Alarm width={20} />
+<Bank />
 <CloudMoon />
 <Github />
 <PaintBucket />

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,10 +120,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bootstrap-icons@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.4.1.tgz#5071d2ea9dab0ad79ca5673a97a0074872c74e14"
-  integrity sha512-EcATaAGsRgyy4NtnwXlNzkgWttpb6PqcXCoLtZZKdZtAYJU/WYqoQFxuGFKAppOlf7NmKpvGtSsC/921H7LIjg==
+bootstrap-icons@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz#2cb19da148aa9105cb3174de2963564982d3dc55"
+  integrity sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -669,10 +669,10 @@ rollup@^2.36.2:
   optionalDependencies:
     fsevents "~2.1.2"
 
-rollup@^2.46.0:
-  version "2.46.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.46.0.tgz#8cacf89d2ee31a34755f1af40a665168f592b829"
-  integrity sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==
+rollup@^2.47.0:
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.47.0.tgz#9d958aeb2c0f6a383cacc0401dff02b6e252664d"
+  integrity sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==
   optionalDependencies:
     fsevents "~2.3.1"
 


### PR DESCRIPTION
- Upgrade `bootstrap-icons` to version 1.4.0 (+45 icons)