### PR TITLE
chore: add module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "svelte": "./lib/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "dev": "rollup -cw",


### PR DESCRIPTION
The package's `*.js` files are all ESM. Therefore this value should exist in `package.json`. While Svelte/SvelteKit are smart enough to figure this out and not trip over it (via Vite/Rollup), Node's default ESM loading needs this to exist. This helps with setups like using jest with ESM support.

An alternative would be explicitly using the `*.mjs` extension.

This could also be categorized as "fix" if you prefer, since the aforementioned jest setup blows up without it.