### PR TITLE
chore(deps-dev): upgrade bootstrap-icons to v1.7.2

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1414,8 +1414,8 @@
 - TicketDetailedFill
 - TicketDetailed
 - TicketFill
-- TicketPerferatedFill
-- TicketPerferated
+- TicketPerforatedFill
+- TicketPerforated
 - Ticket
 - Tiktok
 - ToggleOff

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "bootstrap-icons": "1.7.1",
+    "bootstrap-icons": "1.7.2",
     "gh-pages": "^3.2.3",
-    "rollup": "^2.60.0",
+    "rollup": "^2.60.2",
     "sveld": "^0.8",
     "svelte-check": "^2.2.10",
     "svelte-readme": "^3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,10 +165,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bootstrap-icons@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.7.1.tgz#c17840862845bc11dcc5f69e4ed6f853415df2fd"
-  integrity sha512-Hkuoo0qrWegA9cdzwS68YPSOLf7d42gqnMzT1tIy/SWvnxnI+Y5PFvK2qIbM/L7knH8SdC8FPgjA+bktzmGcAw==
+bootstrap-icons@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.7.2.tgz#4024e081e2c850602552e1fed6451e682d09322a"
+  integrity sha512-NiR2PqC73AQOPdVSu6GJfnk+hN2z6powcistXk1JgPnKuoV2FSdSl26w931Oz9HYbKCcKUSB6ncZTYJAYJl3QQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -921,10 +921,10 @@ rollup@^2.36.0, rollup@^2.36.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^2.60.0:
-  version "2.60.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.60.0.tgz#4ee60ab7bdd0356763f87d7099f413e5460fc193"
-  integrity sha512-cHdv9GWd58v58rdseC8e8XIaPUo8a9cgZpnCMMDGZFDZKEODOiPPEQFXLriWr/TjXzhPPmG5bkAztPsOARIcGQ==
+rollup@^2.60.2:
+  version "2.60.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.60.2.tgz#3f45ace36a9b10b4297181831ea0719922513463"
+  integrity sha512-1Bgjpq61sPjgoZzuiDSGvbI1tD91giZABgjCQBKM5aYLnzjq52GoDuWVwT/cm/MCxCMPU8gqQvkj8doQ5C8Oqw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
**Fixes**

- Upgrade `bootstrap-icons` to v1.7.2 (fixes typo in two icons)